### PR TITLE
python3 compatibility

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -79,7 +79,7 @@ setup(
         "requests==2.2.1",
         "pycontracts==1.7.6",
         "celery==3.1.11",
-        "gevent==1.0.2",
+        "gevent==1.1.2",
         "redis==2.9.1",
         "six==1.9.0"
     ],


### PR DESCRIPTION
While the package is being tested against python 3.3, 3.4, and 3.5
upstream, it seems that the hard dependency on "gevent==1.0.2"
results in an install failure under Python 3.5.1.

    Traceback (most recent call last):
    ...
      File "/private/var/folders/r_/y0nsq9k54tn0rpgh62m6t4_40000gn/T/pip-build-pi5tyo08/gevent/setup.py", line 111, in make_universal_header
        print >>f, line
    TypeError: unsupported operand type(s) for >>: 'builtin_function_or_method' and '_io.TextIOWrapper'

Upgrading to a 1.1.x release of gevent, which appears to include
python3 support.
- http://www.gevent.org/whatsnew_1_0.html
- http://www.gevent.org/whatsnew_1_1.html